### PR TITLE
Transformed vector constructors into static methods

### DIFF
--- a/src/main/java/org/terasology/math/geom/ImmutableVector2d.java
+++ b/src/main/java/org/terasology/math/geom/ImmutableVector2d.java
@@ -31,17 +31,9 @@ public final class ImmutableVector2d extends Tuple2d {
      * @param x the x component
      * @param y the y component
      */
-    public ImmutableVector2d(double x, double y) {
+    ImmutableVector2d(double x, double y) {
         this.x = x;
         this.y = y;
-    }
-
-    /**
-     * Copy constructor
-     * @param other The Tuple2d to copy.
-     */
-    public ImmutableVector2d(Tuple2d other) {
-        this(other.getX(), other.getY());
     }
 
     @Override

--- a/src/main/java/org/terasology/math/geom/Tuple2d.java
+++ b/src/main/java/org/terasology/math/geom/Tuple2d.java
@@ -54,6 +54,47 @@ public abstract class Tuple2d {
     public abstract double getY();
 
     /**
+     * @return a mutable vector (0, 0)
+     */
+    public static Vector2d create() {
+        return new Vector2d(0, 0);
+    }
+
+    /**
+     * @param x the x component
+     * @param y the y component
+     * @return a mutable vector (x, y)
+     */
+    public static Vector2d create(double x, double y) {
+        return new Vector2d(x, y);
+    }
+    
+    /**
+     * @param t the original tuple
+     * @return a mutable copy of t
+     */
+    public static Vector2d create(Tuple2d t) {
+        return new Vector2d(t.getX(), t.getY());
+    }
+    
+    /**
+     * @param x the x component
+     * @param y the y component
+     * @return an immutable vector
+     */
+    public static ImmutableVector2d createImmutable(double x, double y) {
+        return new ImmutableVector2d(x, y);
+    }
+
+    /**
+     * @param t the tuple
+     * @return an immutable vector (a copy of t)
+     */
+    public static ImmutableVector2d createImmutable(Tuple2d t) {
+        return new ImmutableVector2d(t.getX(), t.getY());
+    }
+
+    /**
      * Calculates the linear interpolation between two Tuple2ds.
      * @param a the starting value
      * @param b the ending value

--- a/src/main/java/org/terasology/math/geom/Vector2d.java
+++ b/src/main/java/org/terasology/math/geom/Vector2d.java
@@ -31,25 +31,9 @@ public class Vector2d extends Tuple2d {
      * @param x the x coordinate
      * @param y the y coordinate
      */
-    public Vector2d(double x, double y) {
+    Vector2d(double x, double y) {
         this.x = x;
         this.y = y;
-    }
-
-    /**
-     * Copy constructor
-     *
-     * @param other The Tuple2d to copy
-     */
-    public Vector2d(Tuple2d other) {
-        this.x = other.getX();
-        this.y = other.getY();
-    }
-
-    /**
-     * Default constructor, for a zero vector
-     */
-    public Vector2d() {
     }
 
     @Override

--- a/src/test/java/org/terasology/math/geom/Vector2dTest.java
+++ b/src/test/java/org/terasology/math/geom/Vector2dTest.java
@@ -16,11 +16,10 @@
 
 package org.terasology.math.geom;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Some Point2D related tests
@@ -29,7 +28,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class Vector2dTest extends BaseTuple2dTest {
 
-    private Vector2d v = new Vector2d();
+    private Vector2d v = Tuple2d.create();
 
     @Test
     public void testEquals() {
@@ -44,7 +43,7 @@ public class Vector2dTest extends BaseTuple2dTest {
 
     @Test
     public void emptyConstructorIsIdentityVector() {
-        assertEquals(new Vector2d(0, 0), new Vector2d());
+        assertEquals(new Vector2d(0, 0), Tuple2d.create());
     }
 
     @Test


### PR DESCRIPTION
The idea behind this is to have a consistent way of creating instances. For points/vector this is not a big issue to use public constructors, but rectangle/matrix/quaternion classes could have constructors with identical parameter types.

What do you guys think?
