### PR TITLE
Updated logging libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,17 +51,17 @@ sourceSets {
 
 // Primary dependencies definition
 dependencies {
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.6'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
     compile group: 'com.google.guava', name: 'guava', version: '15.0'
     compile group: 'org.antlr', name: 'ST4', version: '4.0.7'
     
-    generatorCompile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.6'
+    generatorCompile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
     generatorCompile group: 'com.google.guava', name: 'guava', version: '15.0'
     generatorCompile group: 'org.antlr', name: 'ST4', version: '4.0.7'
 
     // These dependencies are only needed for running tests
     testCompile group: 'junit', name: 'junit', version: '4.11'
-    testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.1'
+    testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'
 }
 
 // Set the expected module Java level (can use a higher Java to run, but should not use features from a higher Java)


### PR DESCRIPTION
This updates slf4j from 1.7.6 to 1.7.7 and Logback from 1.1.1 to 1.1.2 (both released in April 2014)

Changelogs
http://www.slf4j.org/news.html
http://logback.qos.ch/news.html
