### PR TITLE
Add more geometric functionality

### DIFF
--- a/src/main/java/org/terasology/math/geom/BoundingBox.java
+++ b/src/main/java/org/terasology/math/geom/BoundingBox.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.math.geom;
+
+import java.util.Collection;
+
+/**
+ * Defines a axis-aligned bounding box based on a set of {@link BaseVector2f} instances.
+ */
+public final class BoundingBox {
+    private float x1;
+    private float y1;
+    private float x2;
+    private float y2;
+
+    private boolean empty = true;
+
+    /**
+     * Default, empty constructor
+     */
+    public BoundingBox() {
+        x1 = Float.POSITIVE_INFINITY;
+        y1 = Float.POSITIVE_INFINITY;
+        x2 = Float.NEGATIVE_INFINITY;
+        y2 = Float.NEGATIVE_INFINITY;
+    }
+
+    /**
+     * @param pt the initial point
+     */
+    public BoundingBox(BaseVector2f pt) {
+        x1 = pt.getX();
+        y1 = pt.getY();
+        x2 = pt.getX();
+        y2 = pt.getY();
+
+        empty = false;
+    }
+
+    /**
+     * Computes the bounding box of the given point set
+     * @param pts a non-empty collection of points
+     * @return the bounding box
+     */
+    public static Rect2f compute(Collection<? extends BaseVector2f> pts) {
+        BoundingBox bbox = new BoundingBox();
+        bbox.addAll(pts);
+        return bbox.toRect2f();
+    }
+
+    /**
+     * Resizes to include the given point
+     * @param pt the Vector2i
+     */
+    public void add(BaseVector2f pt) {
+        add(pt.getX(), pt.getY());
+    }
+
+    /**
+     * Resizes to include all points
+     * @param pts a collection of points
+     */
+    public void addAll(Collection<? extends BaseVector2f> pts) {
+        for (BaseVector2f pt : pts) {
+            add(pt.getX(), pt.getY());
+        }
+    }
+
+    /**
+     * Resizes to include (x, y)
+     * @param x the x coord.
+     * @param y the y coord.
+     */
+    public void add(float x, float y) {
+        if (x < x1) {
+            x1 = x;
+        }
+
+        if (y < y1) {
+            y1 = y;
+        }
+
+        if (x > x2) {
+            x2 = x;
+        }
+
+        if (y > y2) {
+            y2 = y;
+        }
+
+        empty = false;
+    }
+
+    /**
+     * @return true if the bounding box is empty
+     */
+    public boolean isEmpty() {
+        return empty;
+    }
+
+    /**
+     * @return a new Rect2f instance containing the bounds or {@link Rect2f#EMPTY} if empty.
+     */
+    public Rect2f toRect2f() {
+        if (empty) {
+            return Rect2f.EMPTY;
+        }
+
+        return Rect2f.createFromMinAndMax(x1, y1, x2, y2);
+    }
+}

--- a/src/main/java/org/terasology/math/geom/Circle.java
+++ b/src/main/java/org/terasology/math/geom/Circle.java
@@ -68,6 +68,12 @@ public final class Circle implements Shape {
         return radius;
     }
 
+    @Override
+    public Rect2f getBounds() {
+        float dia = radius * 2f;
+        return Rect2f.createFromMinAndSize(center.x() - radius, center.y() - radius, dia, dia);
+    }
+
     /**
      * @return true if the distance is <= radius
      */

--- a/src/main/java/org/terasology/math/geom/LineSegment.java
+++ b/src/main/java/org/terasology/math/geom/LineSegment.java
@@ -68,6 +68,15 @@ public final class LineSegment {
     }
 
     /**
+     * Perform a linear interpolation between the segment endpoints.
+     * @param val the interpolation factor. A value of zero return start, a value of one return end.
+     * @return the interpolated point
+     */
+    public Vector2f lerp(float val) {
+        return BaseVector2f.lerp(start, end, val);
+    }
+
+    /**
      * Computes the smallest distance to a given point in 2D space
      * @param pointP the point to test
      * @return the smallest distance

--- a/src/main/java/org/terasology/math/geom/Polygon.java
+++ b/src/main/java/org/terasology/math/geom/Polygon.java
@@ -18,6 +18,7 @@ package org.terasology.math.geom;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
@@ -26,9 +27,12 @@ import com.google.common.collect.ImmutableList.Builder;
  */
 public final class Polygon implements Shape {
 
-    private final List<ImmutableVector2f> vertices;
+    private final ImmutableList<ImmutableVector2f> vertices;
+    private Rect2f bbox;
 
-    private Polygon(List<ImmutableVector2f> vertices) {
+    private Polygon(ImmutableList<ImmutableVector2f> vertices) {
+        Preconditions.checkArgument(!vertices.isEmpty(), "vertices must not be empty");
+
         this.vertices = vertices;
     }
 
@@ -56,6 +60,14 @@ public final class Polygon implements Shape {
      */
     public float area() {
         return (float) Math.abs(signedArea());
+    }
+
+    @Override
+    public Rect2f getBounds() {
+        if (bbox == null) {
+            bbox = BoundingBox.compute(vertices);
+        }
+        return bbox;
     }
 
     /**

--- a/src/main/java/org/terasology/math/geom/Rect2f.java
+++ b/src/main/java/org/terasology/math/geom/Rect2f.java
@@ -76,6 +76,11 @@ public final class Rect2f extends BaseRect {
         return this == EMPTY;
     }
 
+    @Override
+    public Rect2f getBounds() {
+        return this;
+    }
+
     /**
      * @return The smallest vector in the region
      */

--- a/src/main/java/org/terasology/math/geom/Rect2i.java
+++ b/src/main/java/org/terasology/math/geom/Rect2i.java
@@ -82,6 +82,11 @@ public class Rect2i extends BaseRect {
         return w == 0 || h == 0;
     }
 
+    @Override
+    public Rect2f getBounds() {
+        return Rect2f.createFromMinAndSize(posX, posY, w, h);
+    }
+
     /**
      * @return The smallest vector in the region
      */

--- a/src/main/java/org/terasology/math/geom/Rect2i.java
+++ b/src/main/java/org/terasology/math/geom/Rect2i.java
@@ -263,11 +263,16 @@ public class Rect2i extends BaseRect {
         return result;
     }
 
+
     public Rect2i expand(Vector2i amount) {
+        return expand(amount.getX(), amount.getY());
+    }
+
+    public Rect2i expand(int dx, int dy) {
         Vector2i expandedMin = min();
-        expandedMin.sub(amount);
+        expandedMin.sub(dx, dy);
         Vector2i expandedMax = max();
-        expandedMax.add(amount);
+        expandedMax.add(dx, dy);
         return createFromMinAndMax(expandedMin, expandedMax);
     }
 

--- a/src/main/java/org/terasology/math/geom/Shape.java
+++ b/src/main/java/org/terasology/math/geom/Shape.java
@@ -43,4 +43,9 @@ public interface Shape {
      * @return true if the polygon contains the point
      */
     boolean contains(float x, float y);
+
+    /**
+     * @return the bounding box of the shape
+     */
+    Rect2f getBounds();
 }

--- a/src/test/java/org/terasology/math/geom/PolygonTest.java
+++ b/src/test/java/org/terasology/math/geom/PolygonTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.math.geom;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests the {@link Polygon} class.
+ */
+public class PolygonTest {
+
+    @Test
+    public void testBoundingBox() {
+        Polygon poly = Polygon.createCopy(Arrays.asList(
+                new Vector2f(1, 0),
+                new Vector2f(0, 1),
+                new Vector2f(1, 2),
+                new Vector2f(2, 1)));
+        Assert.assertEquals(Rect2f.createFromMinAndMax(0, 0, 2, 2), poly.getBounds());
+    }
+}


### PR DESCRIPTION
This PR adds

* Rect2i.expand(int, int)
* LineSegment.lerp(float)
* Shape.getBounds() - similar to `awt.Shape`

This includes `BoundingBox` (taken from CommonWorld) to compute the bounding box for polygons.