### PR TITLE
Fix discrete Line/Rectangle intersection tests

### DIFF
--- a/src/main/java/org/terasology/math/TeraMath.java
+++ b/src/main/java/org/terasology/math/TeraMath.java
@@ -631,4 +631,40 @@ public final class TeraMath {
     public static float sqr(int i) {
         return i * i;
     }
+
+    /**
+     * Returns the floating-point value adjacent to {@code d} in the direction of negative infinity.
+     * @param f  starting floating-point value
+     * @return The adjacent floating-point value closer to negative infinity.
+     * @deprecated Use {@link Math#nextDown(float)} if Java 8 is available.
+     */
+    @Deprecated
+    public static float nextDown(float f) {
+        if (Float.isNaN(f) || f == Float.NEGATIVE_INFINITY) {
+            return f;
+        } else {
+            if (f == 0.0f) {
+                return -Float.MIN_VALUE;
+            } else {
+                return Float.intBitsToFloat(Float.floatToRawIntBits(f) + ((f > 0.0f) ? -1 : 1));
+            }
+        }
+    }
+
+    /**
+     * Returns the floating-point value adjacent to {@code f} in the direction of positive infinity.
+     * @param f starting floating-point value
+     * @return The adjacent floating-point value closer to positive infinity.
+     * @deprecated Use {@link Math#nextUp(float)} if Java 8 is available.
+     */
+    @Deprecated
+    public static float nextUp(float f) {
+        if (Float.isNaN(f) || f == Float.POSITIVE_INFINITY) {
+            return f;
+        } else {
+            f += 0.0f;
+            return Float.intBitsToFloat(Float.floatToRawIntBits(f) + ((f >= 0.0f) ? 1 : -1));
+        }
+    }
+
 }

--- a/src/main/java/org/terasology/math/geom/LineSegment.java
+++ b/src/main/java/org/terasology/math/geom/LineSegment.java
@@ -16,7 +16,7 @@
 
 package org.terasology.math.geom;
 
-import java.util.Objects;
+import org.terasology.math.TeraMath;
 
 /**
  * Defines a line segment
@@ -159,14 +159,14 @@ public final class LineSegment {
             if ((out1 & (BaseRect.OUT_LEFT | BaseRect.OUT_RIGHT)) != 0) {
                 float x = rc.minX();
                 if ((out1 & BaseRect.OUT_RIGHT) != 0) {
-                    x = Math.nextDown(x + rc.width());
+                    x = TeraMath.nextDown(x + rc.width());
                 }
                 y1 = y1 + (x - x1) * (y2 - y1) / (x2 - x1);
                 x1 = x;
             } else {
                 float y = rc.minY();
                 if ((out1 & BaseRect.OUT_BOTTOM) != 0) {
-                    y = Math.nextDown(y + rc.height());
+                    y = TeraMath.nextDown(y + rc.height());
                 }
                 x1 = x1 + (y - y1) * (x2 - x1) / (y2 - y1);
                 y1 = y;
@@ -190,9 +190,9 @@ public final class LineSegment {
         float y2 = end.getY();
 
         float minX = rect.minX();
-        float maxX = Math.nextDown(rect.minX() + rect.width());
+        float maxX = TeraMath.nextDown(rect.minX() + rect.width());
         float minY = rect.minY();
-        float maxY = Math.nextDown(rect.minY() + rect.height());
+        float maxY = TeraMath.nextDown(rect.minY() + rect.height());
 
         int f1 = rect.outcode(x1, y1);
         int f2 = rect.outcode(x2, y2);
@@ -264,7 +264,11 @@ public final class LineSegment {
 
     @Override
     public int hashCode() {
-        return Objects.hash(start, end);
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + start.hashCode();
+        result = prime * result + end.hashCode();
+        return result;
     }
 
     @Override

--- a/src/main/java/org/terasology/math/geom/LineSegment.java
+++ b/src/main/java/org/terasology/math/geom/LineSegment.java
@@ -159,14 +159,14 @@ public final class LineSegment {
             if ((out1 & (BaseRect.OUT_LEFT | BaseRect.OUT_RIGHT)) != 0) {
                 float x = rc.minX();
                 if ((out1 & BaseRect.OUT_RIGHT) != 0) {
-                    x += rc.width();
+                    x = Math.nextDown(x + rc.width());
                 }
                 y1 = y1 + (x - x1) * (y2 - y1) / (x2 - x1);
                 x1 = x;
             } else {
                 float y = rc.minY();
                 if ((out1 & BaseRect.OUT_BOTTOM) != 0) {
-                    y += rc.height();
+                    y = Math.nextDown(y + rc.height());
                 }
                 x1 = x1 + (y - y1) * (x2 - x1) / (y2 - y1);
                 y1 = y;
@@ -190,9 +190,9 @@ public final class LineSegment {
         float y2 = end.getY();
 
         float minX = rect.minX();
-        float maxX = rect.maxX();
+        float maxX = Math.nextDown(rect.minX() + rect.width());
         float minY = rect.minY();
-        float maxY = rect.maxY();
+        float maxY = Math.nextDown(rect.minY() + rect.height());
 
         int f1 = rect.outcode(x1, y1);
         int f2 = rect.outcode(x2, y2);

--- a/src/main/java/org/terasology/math/geom/Rect2f.java
+++ b/src/main/java/org/terasology/math/geom/Rect2f.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.math.geom;
 
-import java.util.Objects;
-
 /**
  * @author Immortius
  */
@@ -261,7 +259,13 @@ public final class Rect2f extends BaseRect {
 
     @Override
     public int hashCode() {
-        return Objects.hash(posX, posY, w, h);
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Float.floatToIntBits(posX);
+        result = prime * result + Float.floatToIntBits(posY);
+        result = prime * result + Float.floatToIntBits(w);
+        result = prime * result + Float.floatToIntBits(h);
+        return result;
     }
 
     @Override

--- a/src/main/java/org/terasology/math/geom/Rect2f.java
+++ b/src/main/java/org/terasology/math/geom/Rect2f.java
@@ -234,14 +234,14 @@ public final class Rect2f extends BaseRect {
             out |= OUT_LEFT | OUT_RIGHT;
         } else if (x < this.posX) {
             out |= OUT_LEFT;
-        } else if (x > this.posX + this.w) {
+        } else if (x >= this.posX + this.w) {
             out |= OUT_RIGHT;
         }
         if (this.h <= 0) {
             out |= OUT_TOP | OUT_BOTTOM;
         } else if (y < this.posY) {
             out |= OUT_TOP;
-        } else if (y > this.posY + this.h) {
+        } else if (y >= this.posY + this.h) {
             out |= OUT_BOTTOM;
         }
         return out;

--- a/src/main/java/org/terasology/math/geom/Rect2i.java
+++ b/src/main/java/org/terasology/math/geom/Rect2i.java
@@ -296,14 +296,14 @@ public class Rect2i extends BaseRect {
             out |= OUT_LEFT | OUT_RIGHT;
         } else if (x < this.posX) {
             out |= OUT_LEFT;
-        } else if (x > this.posX + this.w) {
+        } else if (x >= this.posX + this.w) {
             out |= OUT_RIGHT;
         }
         if (this.h <= 0) {
             out |= OUT_TOP | OUT_BOTTOM;
         } else if (y < this.posY) {
             out |= OUT_TOP;
-        } else if (y > this.posY + this.h) {
+        } else if (y >= this.posY + this.h) {
             out |= OUT_BOTTOM;
         }
         return out;

--- a/src/main/java/org/terasology/math/geom/Rect2i.java
+++ b/src/main/java/org/terasology/math/geom/Rect2i.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Lists;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 
 /**
  * 2D Rectangle
@@ -227,7 +226,13 @@ public class Rect2i extends BaseRect {
 
     @Override
     public int hashCode() {
-        return Objects.hash(posX, posY, w, h);
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + posX;
+        result = prime * result + posY;
+        result = prime * result + w;
+        result = prime * result + h;
+        return result;
     }
 
     @Override

--- a/src/test/java/org/terasology/math/geom/InteractiveIntersectionTest.java
+++ b/src/test/java/org/terasology/math/geom/InteractiveIntersectionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.math.geom;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.geom.Ellipse2D;
+
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+
+/**
+ * Use the main method to start.
+ */
+public final class InteractiveIntersectionTest {
+
+
+    private static Point pt;
+
+    private InteractiveIntersectionTest() {
+        // private
+    }
+
+    /**
+     * @param args (ignored)
+     */
+    public static void main(String[] args) {
+        // Create and set up the window.
+        final JFrame frame = new JFrame("Symmetry Test");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        JComponent comp = new JComponent() {
+            private static final long serialVersionUID = -3019274194814342555L;
+
+            @Override
+            protected void paintComponent(final Graphics g1) {
+                super.paintComponent(g1);
+                final Graphics2D g = (Graphics2D) g1;
+                int scale = 8;
+                int centerX = getWidth() / (2 * scale);
+                int centerY = getHeight() / (2 * scale);
+                g.scale(scale, scale);
+
+                g.setColor(Color.BLACK);
+                g.setStroke(new BasicStroke(0.1f));
+                g.drawRect(23, 25, 14, 8);
+
+                if (pt != null) {
+                    Vector2i mp = new Vector2i(pt.x / scale, pt.y / scale);
+
+                    float mouseX = mp.getX();
+                    float mouseY = mp.getY();
+
+                    if (Circle.intersects(mouseX, mouseY, 10, Rect2i.createFromMinAndSize(23, 25, 14, 8))) {
+                        g.setColor(Color.BLUE);
+                    } else {
+                        g.setColor(Color.CYAN);
+                    }
+                    g.draw(new Ellipse2D.Double(mouseX - 10, mouseY - 10, 20, 20));
+                }
+
+                // draw grid
+                g.setStroke(new BasicStroke(0f));
+                g.translate(-0.5f, -0.5f);
+                g.setColor(Color.LIGHT_GRAY);
+                for (int i = 0; i < getWidth() / scale + 1; i++) {
+                    g.drawLine(i, 0, i, getHeight());
+                }
+                for (int i = 0; i < getHeight() / scale + 1; i++) {
+                    g.drawLine(0, i, getWidth(), i);
+                }
+
+                g.setColor(Color.BLACK);
+                g.drawLine(centerX, 0, centerX, getHeight());
+                g.drawLine(0, centerY, getWidth(), centerY);
+
+                g.setStroke(new BasicStroke());
+            }
+        };
+
+        frame.add(comp);
+
+        comp.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseExited(MouseEvent e) {
+                pt = null;
+                e.getComponent().repaint();
+            }
+        });
+
+        comp.addMouseMotionListener(new MouseAdapter() {
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                mouseMoved(e);
+            }
+
+            @Override
+            public void mouseMoved(MouseEvent e) {
+                pt = new Point(e.getX(), e.getY());
+                e.getComponent().repaint();
+            }
+
+        });
+
+        frame.setLocation(500, 200);
+        frame.setSize(600, 400);
+        frame.setVisible(true);
+    }
+}

--- a/src/test/java/org/terasology/math/geom/LineSegmentTest.java
+++ b/src/test/java/org/terasology/math/geom/LineSegmentTest.java
@@ -16,6 +16,8 @@
 
 package org.terasology.math.geom;
 
+import java.util.Random;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -58,12 +60,37 @@ public class LineSegmentTest {
     @Test
     public void intersectionTest() {
         Rect2i rc = Rect2i.createFromMinAndMax(1, 2, 10, 20);
-        Assert.assertEquals(new LineSegment(5, 6, 10, 12), new LineSegment(5, 6, 10, 12).getClipped(rc));
-        Assert.assertEquals(new LineSegment(1, 2, 5, 6), new LineSegment(0, 1, 5, 6).getClipped(rc));
-        Assert.assertEquals(new LineSegment(3, 4, 8, 9), new LineSegment(3, 4, 8, 9).getClipped(rc));
-        Assert.assertEquals(new LineSegment(1, 5, 10, 5), new LineSegment(0, 5, 15, 5).getClipped(rc));
-        Assert.assertEquals(new LineSegment(2, 2, 2, 20), new LineSegment(2, 0, 2, 25).getClipped(rc));
-        Assert.assertEquals(new LineSegment(1, 2, 10, 2), new LineSegment(0, 2, 30, 2).getClipped(rc));
-        Assert.assertEquals(new LineSegment(10, 20, 10, 20), new LineSegment(8, 22, 12, 18).getClipped(rc));
+        assertSegEquals(new LineSegment(5, 6, 10, 12), new LineSegment(5, 6, 10, 12).getClipped(rc));
+        assertSegEquals(new LineSegment(1, 2, 5, 6), new LineSegment(0, 1, 5, 6).getClipped(rc));
+        assertSegEquals(new LineSegment(3, 4, 8, 9), new LineSegment(3, 4, 8, 9).getClipped(rc));
+        assertSegEquals(new LineSegment(1, 5, 10, 5), new LineSegment(0, 5, 15, 5).getClipped(rc));
+        assertSegEquals(new LineSegment(2, 2, 2, 20), new LineSegment(2, 0, 2, 25).getClipped(rc));
+        assertSegEquals(new LineSegment(1, 2, 10, 2), new LineSegment(0, 2, 30, 2).getClipped(rc));
+        assertSegEquals(new LineSegment(10, 20, 10, 20), new LineSegment(8, 23, 12, 19).getClipped(rc));
+    }
+
+    private void assertSegEquals(LineSegment l1, LineSegment l2) {
+        Assert.assertEquals(new Vector2i(l1.getStart()), new Vector2i(l2.getStart()));
+        Assert.assertEquals(new Vector2i(l1.getEnd()), new Vector2i(l2.getEnd()));
+    }
+
+    @Test
+    public void randomCuts() {
+        Rect2i rc = Rect2i.createFromMinAndSize(3, 3, 5, 5);
+        Vector2f p0 = new Vector2f();
+        Vector2f p1 = new Vector2f();
+
+        Random rng = new Random(123234);
+        for (int i = 0; i < 10000; i++) {
+            float sx = rng.nextFloat() * 10f;
+            float sy = rng.nextFloat() * 10f;
+            float dx = rng.nextFloat() * 10f;
+            float dy = rng.nextFloat() * 10f;
+            LineSegment seg = new LineSegment(sx, sy, dx, dy);
+            if (seg.intersects(rc)) {
+                seg.getClipped(rc, p0, p1);
+                Assert.assertTrue(rc.contains(p0.x, p0.y) && rc.contains(p1.x, p1.y));
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently, the behavior of `Rect2i.outcode` and the intersection tests is inconsistent. This PR rectifies the situation:

* Bottom and right edges are always outside
* Clipping with bottom/right edges results in the largest value that is *inside* the edge

This fixes infinite loops while trying to compute the intersection points as well as intersection points that lie exactly on the bottom/right edges.